### PR TITLE
Add optional address field to User model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,8 @@
+from typing import Optional
 from pydantic import BaseModel
 
 class User(BaseModel):
     id: int
     name: str
     email: str
+    address: Optional[str] = None


### PR DESCRIPTION
## Summary
- Added optional `address` field to the User model to enhance user profile information
- Added necessary `Optional` import from typing module
- Field defaults to `None` for backward compatibility

## Changes Made
- Modified `app/models.py` to include:
  - Import of `Optional` from `typing`
  - New `address: Optional[str] = None` field in User model

## Testing
- [x] Existing functionality remains unchanged
- [x] Model maintains backward compatibility
- [x] Optional field can be None

Closes #26

🤖 Generated with [Claude Code](https://claude.ai/code)